### PR TITLE
fix(chart): bump to 0.3.4 with working icon URL

### DIFF
--- a/charts/scapy/Chart.yaml
+++ b/charts/scapy/Chart.yaml
@@ -3,11 +3,11 @@ apiVersion: v2
 name: scapy
 description: Scapy Helm chart for Kubernetes
 type: application
-version: &version 0.3.3
+version: &version 0.3.4
 appVersion: *version
 kubeVersion: ">= 1.25"
 home: https://github.com/saidsef/scapy-containerised
-icon: https://scapy.net/assets/img/logo.png
+icon: https://raw.githubusercontent.com/secdev/scapy/master/doc/scapy/graphics/scapy_logo.png
 keywords:
   - scapy
   - kubernetes
@@ -25,13 +25,7 @@ annotations:
   artifacthub.io/license: "MIT"
   artifacthub.io/changes: |
     - kind: fixed
-      description: route scapy cache to /tmp via XDG_CACHE_HOME (SCAPY_CACHE_FOLDER was a no-op under read-only root filesystem)
-    - kind: fixed
-      description: silence IPython non-writable parent warning by setting IPYTHONDIR
-    - kind: removed
-      description: SCAPY_CACHE_FOLDER env var, which scapy never read
-    - kind: fixed
-      description: stop the /app emptyDir mount from shadowing the image's scripts/ directory at runtime
+      description: icon URL points to upstream scapy logo (scapy.net no longer hosts /assets/img/logo.png)
   artifacthub.io/links: |
     - name: README
       url: https://github.com/saidsef/scapy-containerised/blob/main/README.md


### PR DESCRIPTION
## Summary

- Bump scapy helm chart to **0.3.4** with the icon URL fixed.
- `https://scapy.net/assets/img/logo.png` 404s; point the icon at the upstream scapy logo on `github.com/secdev/scapy`.
- Reset the `artifacthub.io/changes` block to describe only this release's change (per repo convention).

## Why

Artifact Hub was reporting two errors against the `saidsef/scapy` chart:

1. `error getting logo image https://scapy.net/assets/img/logo.png: unexpected status code received: 404` (every version).
2. `error preparing package: error loading chart (...scapy-0.1.0.tgz): not found` (chart 0.1.0).

This PR clears #1 for the upcoming 0.3.4 release. The matching cleanup on `gh-pages/index.yaml` - replacing the broken icon URL across the 19 historical entries and dropping the stale `0.1.0` entry whose tarball was never published - was pushed separately as a one-off edit on the `gh-pages` branch (commit `21b639e`).

## Test plan

- [x] `helm lint charts/scapy` clean locally.
- [x] `curl -sI https://raw.githubusercontent.com/secdev/scapy/master/doc/scapy/graphics/scapy_logo.png` returns 200.
- [x] `Charts` workflow passes on this PR (chart-testing lint).
- [ ] After merge, `chart-releaser-action` cuts the `scapy-0.3.4` GitHub release and prepends the new entry to `gh-pages/index.yaml`.
- [ ] `curl -s https://saidsef.github.io/scapy-containerised/index.yaml | head -40` shows version 0.3.4 with the new icon URL on top.
- [ ] Artifact Hub re-indexes and both errors clear.